### PR TITLE
relaton/relaton#81 fix Errno::EACCESS Permission denied @ rb_file_s_rename

### DIFF
--- a/lib/relaton_nist/hit_collection.rb
+++ b/lib/relaton_nist/hit_collection.rb
@@ -135,8 +135,9 @@ module RelatonNist
       resp = OpenURI.open_uri("#{PUBS_EXPORT}.meta")
       if !ctime || ctime < resp.last_modified
         @data = nil
+        uri_open = URI.method(:open) || Kernel.method(:open)
         FileUtils.mkdir_p DATAFILEDIR unless Dir.exist? DATAFILEDIR
-        IO.copy_stream(URI.open("#{PUBS_EXPORT}.zip"), DATAFILE)
+        IO.copy_stream(uri_open.call("#{PUBS_EXPORT}.zip"), DATAFILE)
       end
     end
 

--- a/lib/relaton_nist/hit_collection.rb
+++ b/lib/relaton_nist/hit_collection.rb
@@ -10,6 +10,7 @@ module RelatonNist
   # Page of hit collection.
   class HitCollection < RelatonBib::HitCollection
     DOMAIN = "https://csrc.nist.gov"
+    PUBS_EXPORT = URI::join(DOMAIN, "/CSRC/media/feeds/metanorma/pubs-export")
     DATAFILEDIR = File.expand_path ".relaton/nist", Dir.home
     DATAFILE = File.expand_path "pubs-export.zip", DATAFILEDIR
 
@@ -131,15 +132,11 @@ module RelatonNist
     #
     # @prarm ctime [Time, NilClass]
     def fetch_data(ctime)
-      resp = OpenURI.open_uri(
-        "https://csrc.nist.gov/CSRC/media/feeds/metanorma/pubs-export.meta"
-      )
+      resp = OpenURI.open_uri("#{PUBS_EXPORT}.meta")
       if !ctime || ctime < resp.last_modified
         @data = nil
-        zip = OpenURI.open_uri "https://csrc.nist.gov/CSRC/media/feeds/metanorma/pubs-export.zip"
-        zip.close
         FileUtils.mkdir_p DATAFILEDIR unless Dir.exist? DATAFILEDIR
-        FileUtils.mv zip.path, DATAFILE
+        IO.copy_stream(open("#{PUBS_EXPORT}.zip"), DATAFILE)
       end
     end
 

--- a/lib/relaton_nist/hit_collection.rb
+++ b/lib/relaton_nist/hit_collection.rb
@@ -10,7 +10,7 @@ module RelatonNist
   # Page of hit collection.
   class HitCollection < RelatonBib::HitCollection
     DOMAIN = "https://csrc.nist.gov"
-    PUBS_EXPORT = URI::join(DOMAIN, "/CSRC/media/feeds/metanorma/pubs-export")
+    PUBS_EXPORT = URI.join(DOMAIN, "/CSRC/media/feeds/metanorma/pubs-export")
     DATAFILEDIR = File.expand_path ".relaton/nist", Dir.home
     DATAFILE = File.expand_path "pubs-export.zip", DATAFILEDIR
 
@@ -136,7 +136,7 @@ module RelatonNist
       if !ctime || ctime < resp.last_modified
         @data = nil
         FileUtils.mkdir_p DATAFILEDIR unless Dir.exist? DATAFILEDIR
-        IO.copy_stream(open("#{PUBS_EXPORT}.zip"), DATAFILE)
+        IO.copy_stream(URI.open("#{PUBS_EXPORT}.zip"), DATAFILE)
       end
     end
 


### PR DESCRIPTION
 - relaton/relaton#81

The root of the issue the same as https://stackoverflow.com/questions/38342721/ruby-fileutils-move-errnoeacces-permission-denied-on-windows